### PR TITLE
fix(workflow): update Dockerfile path

### DIFF
--- a/.github/workflows/deploy-staging.api.yml
+++ b/.github/workflows/deploy-staging.api.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build and push API image
         run: |
           IMAGE=${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME_API }}:staging
-          docker build -t $IMAGE -f Dockerfile.standalone ./apps/api
+          docker build -t $IMAGE -f ./apps/api/Dockerfile.standalone ./apps/api
           docker push $IMAGE
 
       # 3. SSH into server and deploy via docker-compose


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes the Docker build command to reference `./apps/api/Dockerfile.standalone` in the staging API deploy workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34409705423fbe576d6475753dff94965b0eec16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->