### PR TITLE
chore(workflows): add conectivity testing step

### DIFF
--- a/.github/workflows/deploy-staging.api.yml
+++ b/.github/workflows/deploy-staging.api.yml
@@ -3,8 +3,8 @@ name: 🚀 Deploy as a Staging Environment | Dellbuntu
 on:
   push:
     branches: ['staging-api']
-  pull_request:
-    branches: ['staging-api']
+  # pull_request:
+  #   branches: ['staging-api']
 
 permissions:
   contents: read
@@ -34,7 +34,14 @@ jobs:
           docker build -t $IMAGE -f ./apps/api/Dockerfile.standalone ./apps/api
           docker push $IMAGE
 
-      # 3. SSH into server and deploy via docker-compose
+      # 3. Test server connectivity
+      - name: Test server connectivity
+        run: |
+          echo "Testing connectivity to ${{ secrets.STAGING_HOST }}"
+          ping -c 3 ${{ secrets.STAGING_HOST }} || echo "Ping failed"
+          nc -zv ${{ secrets.STAGING_HOST }} 22 || echo "Port 22 test failed"
+
+      # 4. SSH into server and deploy via docker-compose
       - name: Deploy on server with docker-compose
         # ✅ Use appleboy/ssh-action to SSH into server and deploy via docker-compose
         uses: appleboy/ssh-action@v1.1.0
@@ -56,6 +63,10 @@ jobs:
           host: ${{ env.STAGING_HOST }}
           username: ${{ env.STAGING_USER }}
           key: ${{ env.STAGING_SSH_KEY }}
+          port: 22
+          timeout: 60s
+          command_timeout: 10m
+          retry: 3
           script: |
             set -e
             cd ~/apps/${{ env.PROJECT_NAME }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,8 +3,8 @@ name: 🚀 Deploy as a Staging Environment | Dellbuntu
 on:
   push:
     branches: ['staging']
-  pull_request:
-    branches: ['staging']
+  # pull_request:
+  #   branches: ['staging']
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds server connectivity tests and SSH-action timeouts/retries to the API staging deploy, and disables pull_request triggers for both staging workflows.
> 
> - **Workflows**:
>   - **`/.github/workflows/deploy-staging.api.yml`**:
>     - Add server connectivity test step (`ping`, `nc`) before SSH deploy.
>     - Tune `appleboy/ssh-action` with `port: 22`, `timeout: 60s`, `command_timeout: 10m`, `retry: 3`.
>     - Comment out `pull_request` trigger (runs on `push` only).
>   - **`/.github/workflows/deploy-staging.yml`**:
>     - Comment out `pull_request` trigger (runs on `push` only).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df39111d151ce631db54c6c13e1e8b0db8b5eae3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->